### PR TITLE
fixed scope parameter separator

### DIFF
--- a/src/Auth0.php
+++ b/src/Auth0.php
@@ -75,4 +75,9 @@ class Auth0 extends AbstractProvider
     {
         return new Auth0ResourceOwner($response);
     }
+
+    protected function getScopeSeparator()
+    {
+        return ' ';
+    }
 }

--- a/tests/Auth0Test.php
+++ b/tests/Auth0Test.php
@@ -132,4 +132,25 @@ class Auth0Test extends TestCase
             ->disableOriginalConstructor()
             ->getMock();
     }
+
+    /**
+     * @dataProvider scopeDataProvider
+     */
+    public function testGetAuthorizationUrlWithScopes($scopes, $expectedScopeParameter)
+    {
+        $provider = new OauthProvider(array_merge($this->config, ['scope' => $scopes]));
+
+        $url = $provider->getAuthorizationUrl();
+        $queryString = parse_url($url, PHP_URL_QUERY);
+
+        $this->assertContains($expectedScopeParameter, $queryString);
+    }
+
+    public function scopeDataProvider()
+    {
+        return [
+            [['openid'], 'scope=openid'],
+            [['openid', 'email'], 'scope=openid%20email'],
+        ];
+    }
 }


### PR DESCRIPTION
Fixed the `scope` parameter to be separated by spaces [as stated in the doc](https://github.com/RiskioFr/oauth2-auth0/issues/9).

It is also related to https://github.com/RiskioFr/oauth2-auth0/issues/9