### PR TITLE
added a customDomain parameter that enables to use tenants with custo…

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ You have to provide some parameters to the provider:
 
 - customDomain (optional):
    - description: Custom domain used for the Auth0 login - https://auth0.com/docs/custom-domains
-     (If this is set, the region and account parameters will be ignored.)
+     (I.e.: login.custom-domain.tld - It will be prefixed with https:// automatically. If this is set, the region and account parameters will be ignored.)
 - region (optional):
    - description: Auth0 region
    - values:

--- a/README.md
+++ b/README.md
@@ -22,13 +22,16 @@ Usage is the same as The League's OAuth client, using `Riskio\OAuth2\Client\Prov
 
 You have to provide some parameters to the provider:
 
+- customDomain (optional):
+   - description: Custom domain used for the Auth0 login - https://auth0.com/docs/custom-domains
+     (If this is set, the region and account parameters will be ignored.)
 - region (optional):
    - description: Auth0 region
    - values:
       - Riskio\OAuth2\Client\Provider\Auth0::REGION_US (default value)
       - Riskio\OAuth2\Client\Provider\Auth0::REGION_EU
       - Riskio\OAuth2\Client\Provider\Auth0::REGION_AU
-- account:
+- account (required if customDomain is not set):
    - description: Auth0 account name
 - clientId
    - description: The client ID assigned to you by the provider

--- a/src/Auth0.php
+++ b/src/Auth0.php
@@ -44,22 +44,27 @@ class Auth0 extends AbstractProvider
             $domain = $this->region . '.' . $domain;
         }
 
-        return 'https://' . $this->account . '.' . $domain;
+        return $this->account . '.' . $domain;
+    }
+
+    protected function baseUrl()
+    {
+        return 'https://' . $this->domain();
     }
 
     public function getBaseAuthorizationUrl()
     {
-        return $this->domain() . '/authorize';
+        return $this->baseUrl() . '/authorize';
     }
 
     public function getBaseAccessTokenUrl(array $params = [])
     {
-        return $this->domain() . '/oauth/token';
+        return $this->baseUrl() . '/oauth/token';
     }
 
     public function getResourceOwnerDetailsUrl(AccessToken $token)
     {
-        return $this->domain() . '/userinfo';
+        return $this->baseUrl() . '/userinfo';
     }
 
     public function getDefaultScopes()

--- a/src/Auth0.php
+++ b/src/Auth0.php
@@ -23,8 +23,14 @@ class Auth0 extends AbstractProvider
 
     protected $account;
 
+    protected $customDomain;
+
     protected function domain()
     {
+        if ($this->customDomain !== null) {
+            return $this->customDomain;
+        }
+
         if (empty($this->account)) {
             throw new AccountNotProvidedException();
         }

--- a/tests/Auth0Test.php
+++ b/tests/Auth0Test.php
@@ -161,7 +161,7 @@ class Auth0Test extends TestCase
         $url = $provider->getAuthorizationUrl();
         $expectedBaseUrl = 'https://' . $customDomain;
 
-        $this->assertTrue(0 === strpos($url, $expectedBaseUrl));
+        $this->assertStringStartsWith($expectedBaseUrl, $url);
     }
 
     /**
@@ -180,12 +180,12 @@ class Auth0Test extends TestCase
         $accessTokenDummy = $this->getAccessToken();
 
         $url = $provider->getBaseAuthorizationUrl();
-        $this->assertTrue(0 === strpos($url, $expectedBaseUrl));
+        $this->assertStringStartsWith($expectedBaseUrl, $url);
 
         $url = $provider->getBaseAccessTokenUrl();
-        $this->assertTrue(0 === strpos($url, $expectedBaseUrl));
+        $this->assertStringStartsWith($expectedBaseUrl, $url);
 
         $url = $provider->getResourceOwnerDetailsUrl($accessTokenDummy);
-        $this->assertTrue(0 === strpos($url, $expectedBaseUrl));
+        $this->assertStringStartsWith($expectedBaseUrl, $url);
     }
 }

--- a/tests/Auth0Test.php
+++ b/tests/Auth0Test.php
@@ -156,11 +156,12 @@ class Auth0Test extends TestCase
 
     public function testGetAuthorizationUrlWithCustomDomain()
     {
-        $customDomain = 'https://login.custom-domain.tld';
+        $customDomain = 'login.custom-domain.tld';
         $provider = new OauthProvider(array_merge($this->config, ['customDomain' => $customDomain]));
         $url = $provider->getAuthorizationUrl();
+        $expectedBaseUrl = 'https://' . $customDomain;
 
-        $this->assertTrue(0 === strpos($url, $customDomain));
+        $this->assertTrue(0 === strpos($url, $expectedBaseUrl));
     }
 
     /**
@@ -170,20 +171,21 @@ class Auth0Test extends TestCase
      */
     public function testCustomDomain()
     {
-        $customDomain = 'https://login.custom-domain.tld';
+        $customDomain = 'login.custom-domain.tld';
         $this->config['customDomain'] = $customDomain;
         unset($this->config['account']);
+        $expectedBaseUrl = 'https://' . $customDomain;
 
         $provider = new OauthProvider($this->config);
         $accessTokenDummy = $this->getAccessToken();
 
         $url = $provider->getBaseAuthorizationUrl();
-        $this->assertTrue(0 === strpos($url, $customDomain));
+        $this->assertTrue(0 === strpos($url, $expectedBaseUrl));
 
         $url = $provider->getBaseAccessTokenUrl();
-        $this->assertTrue(0 === strpos($url, $customDomain));
+        $this->assertTrue(0 === strpos($url, $expectedBaseUrl));
 
         $url = $provider->getResourceOwnerDetailsUrl($accessTokenDummy);
-        $this->assertTrue(0 === strpos($url, $customDomain));
+        $this->assertTrue(0 === strpos($url, $expectedBaseUrl));
     }
 }

--- a/tests/Auth0Test.php
+++ b/tests/Auth0Test.php
@@ -153,4 +153,37 @@ class Auth0Test extends TestCase
             [['openid', 'email'], 'scope=openid%20email'],
         ];
     }
+
+    public function testGetAuthorizationUrlWithCustomDomain()
+    {
+        $customDomain = 'https://login.custom-domain.tld';
+        $provider = new OauthProvider(array_merge($this->config, ['customDomain' => $customDomain]));
+        $url = $provider->getAuthorizationUrl();
+
+        $this->assertTrue(0 === strpos($url, $customDomain));
+    }
+
+    /**
+     * Test that URL getters work as expected with custom domain set, and account not set.
+     * They should not throw AccountNotProvidedException (or any exception),
+     * and have to return an url starting with the custom domain.
+     */
+    public function testCustomDomain()
+    {
+        $customDomain = 'https://login.custom-domain.tld';
+        $this->config['customDomain'] = $customDomain;
+        unset($this->config['account']);
+
+        $provider = new OauthProvider($this->config);
+        $accessTokenDummy = $this->getAccessToken();
+
+        $url = $provider->getBaseAuthorizationUrl();
+        $this->assertTrue(0 === strpos($url, $customDomain));
+
+        $url = $provider->getBaseAccessTokenUrl();
+        $this->assertTrue(0 === strpos($url, $customDomain));
+
+        $url = $provider->getResourceOwnerDetailsUrl($accessTokenDummy);
+        $this->assertTrue(0 === strpos($url, $customDomain));
+    }
 }


### PR DESCRIPTION
…m domain set

This PR enables this library to work with auth0 tenants that use [custom domains](https://auth0.com/docs/custom-domains).

It is implemented in a backward compatible way.

The new parameter (`customDomain`) is optional. The `region` and `account` parameters will be ignored if it's set.