### PR TITLE
Throw exception instead of returning it

### DIFF
--- a/src/Auth0.php
+++ b/src/Auth0.php
@@ -76,7 +76,7 @@ class Auth0 extends AbstractProvider
     protected function checkResponse(ResponseInterface $response, $data)
     {
         if ($response->getStatusCode() >= 400) {
-            return Auth0IdentityProviderException::fromResponse(
+            throw Auth0IdentityProviderException::fromResponse(
                 $response,
                 $data['error'] ?: $response->getReasonPhrase()
             );


### PR DESCRIPTION
Currently the `Auth0IdentityProviderException` is never thrown which results in a vague `InvalidArgumentException` being thrown in `League\OAuth2\Client\Token\AccessToken` when the response is invalid.